### PR TITLE
changed to using an ES6 class

### DIFF
--- a/src/session-decoder.js
+++ b/src/session-decoder.js
@@ -1,59 +1,68 @@
-const crypto = require("crypto")
-    , base64url = require('base64url')
-    , msgpack = require('msgpack-javascript')
-    , long = require("long");
+'use strict';
 
-function SessionDecoder(publicKey) {
-    this.publicKey = convertPublicKeyToPEM(publicKey);
+const crypto = require('crypto');
+const base64url = require('base64url');
+const msgpack = require('msgpack-javascript');
+const long = require('long');
 
-    function convertPublicKeyToPEM(publicKey) {
-        const base64PublicKey = base64url.toBase64(publicKey);
-        const beginString = '-----BEGIN PUBLIC KEY-----\n';
-        const endString = '\n-----END PUBLIC KEY-----';
-        return beginString + base64PublicKey.replace(/(.{64})/g, "$1") + endString;
-    }
+function convertPublicKeyToPEM(publicKey) {
+	const base64PublicKey = base64url.toBase64(publicKey);
 
-    function getSessionFromTokenBuffer(sessionTokenBuffer) {
-        const unpacker = new msgpack.Unpacker(sessionTokenBuffer);
-        const unpackedLong1 = unpacker.unpackInt();
-        const unpackedLong2 = unpacker.unpackInt();
-
-        const mostSignificantBits = new long(unpackedLong1.low, unpackedLong1.high);
-        const leastSignificantBits = new long(unpackedLong2.low, unpackedLong2.high);
-        return uuidFrom(mostSignificantBits, leastSignificantBits);
-    }
-
-    function uuidFrom(mostSig, leastSig) {
-        return toHexDigits(mostSig.shiftRight(32), 8)  + "-" +
-               toHexDigits(mostSig.shiftRight(16), 4)  + "-" +
-               toHexDigits(mostSig, 4)                 + "-" +
-               toHexDigits(leastSig.shiftRight(48), 4) + "-" +
-               toHexDigits(leastSig, 12);
-    }
-
-    function toHexDigits(val, digits) {
-        const hi = new long(1).shiftLeft((digits * 4));
-        return hi.or((val.and((hi - 1)))).toString(16).substring(1);
-    }
-
-    this.decode = (sessionValue) => {
-        const split = sessionValue.split(".");
-        if (split.length !== 2) {
-            throw "Invalid session - incorrect format"
-        }
-        const base64EncodedToken = split[0];
-        const base64EncodedSignature = split[1];
-        const sessionTokenBuffer = new Buffer(base64EncodedToken, 'base64');
-        const verifier = crypto.createVerify('SHA256');
-
-        verifier.update(sessionTokenBuffer);
-
-        const verified = verifier.verify(this.publicKey, base64EncodedSignature, 'base64');
-        if (verified) {
-            return getSessionFromTokenBuffer(sessionTokenBuffer);
-        } else {
-            throw "Invalid session - signature verification failed";
-        }
-    }
+	return `-----BEGIN PUBLIC KEY-----
+${base64PublicKey.replace(/(.{64})/g, '$1')}
+-----END PUBLIC KEY-----`;
 }
+
+function getSessionFromTokenBuffer(sessionTokenBuffer) {
+	const unpacker = new msgpack.Unpacker(sessionTokenBuffer);
+	const unpackedLong1 = unpacker.unpackInt();
+	const unpackedLong2 = unpacker.unpackInt();
+
+	const mostSignificantBits = new long(unpackedLong1.low, unpackedLong1.high);
+	const leastSignificantBits = new long(unpackedLong2.low, unpackedLong2.high);
+	return uuidFrom(mostSignificantBits, leastSignificantBits);
+}
+
+function uuidFrom(mostSig, leastSig) {
+	return [
+		toHexDigits(mostSig.shiftRight(32), 8),
+		toHexDigits(mostSig.shiftRight(16), 4),
+		toHexDigits(mostSig, 4),
+		toHexDigits(leastSig.shiftRight(48), 4),
+		toHexDigits(leastSig, 12)
+	].join('-');
+}
+
+function toHexDigits(val, digits) {
+	const hi = new long(1).shiftLeft((digits * 4));
+	return hi.or((val.and((hi - 1)))).toString(16).substring(1);
+}
+
+
+class SessionDecoder {
+	constructor (publicKey) {
+		this.publicKey = convertPublicKeyToPEM(publicKey);
+	}
+
+	decode (sessionValue) {
+		const split = sessionValue.split('.');
+		if (split.length !== 2) {
+			throw new Error('Invalid session - incorrect format');
+		}
+		const base64EncodedToken = split[0];
+		const base64EncodedSignature = split[1];
+		const sessionTokenBuffer = new Buffer(base64EncodedToken, 'base64');
+		const verifier = crypto.createVerify('SHA256');
+
+		verifier.update(sessionTokenBuffer);
+
+		const verified = verifier.verify(this.publicKey, base64EncodedSignature, 'base64');
+		if (verified) {
+			return getSessionFromTokenBuffer(sessionTokenBuffer);
+		} else {
+			throw new Error('Invalid session - signature verification failed');
+		}
+	}
+}
+
 module.exports = SessionDecoder;


### PR DESCRIPTION
@tjcutajar I've updated to use a class as it makes it easier to write tests in upstream dependencies, and also throwing error objects rather than strings as this will mean a stack trace is captured