### PR TITLE
Remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@financial-times/n-gage": "^8.2.0",
     "chai": "^3.5.0",
-    "lodash": "^4.17.15",
     "mocha": "^2.5.3",
     "npm-prepublish": "^1.2.1",
     "nyc": "^15.0.1",


### PR DESCRIPTION
This dependency was added in 2d29cdb07a6e993bec9d4010580ec904cf3db993 (PR #20) to fix failing tests but it also introduces some security vulnerabilities.

It's only a devDependency but it does pollute the reporting of vulnerabilities.