### PR TITLE
Replace msgpack-javascript with msgpackr

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "base64url": "3.0.1",
     "long": "3.2.0",
-    "msgpack-javascript": "0.10.0"
+    "msgpackr": "^1.5.2"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.2.0",

--- a/src/session-decoder.js
+++ b/src/session-decoder.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto');
 const base64url = require('base64url');
-const msgpack = require('msgpack-javascript');
+const msgpack = require('msgpackr');
 const long = require('long');
 
 function convertPublicKeyToPEM (publicKey) {
@@ -14,12 +14,10 @@ ${base64PublicKey.replace(/(.{64})/g, '$1')}
 }
 
 function getSessionFromTokenBuffer (sessionTokenBuffer) {
-	const unpacker = new msgpack.Unpacker(sessionTokenBuffer);
-	const unpackedLong1 = unpacker.unpackInt();
-	const unpackedLong2 = unpacker.unpackInt();
+	const unpackedValues = msgpack.unpackMultiple(sessionTokenBuffer);
 
-	const mostSignificantBits = new long(unpackedLong1.low, unpackedLong1.high);
-	const leastSignificantBits = new long(unpackedLong2.low, unpackedLong2.high);
+	const mostSignificantBits = new long.fromString(unpackedValues[0].toString());
+	const leastSignificantBits = new long.fromString(unpackedValues[1].toString());
 	return uuidFrom(mostSignificantBits, leastSignificantBits);
 }
 


### PR DESCRIPTION
[msgpack-javascript](https://www.npmjs.com/package/msgpack-javascript) hasn't been published since 5 years ago and has ~50 weekly downloads from npm (most of these are probably us).

[msgpackr](https://www.npmjs.com/package/msgpackr) was last updated a day ago and has ~200k weekly downloads.

msgpack-javascript is pinned to some very old dependencies including a version of lodash with known vulnerabilities and it doesn't look like it's ever going to get touched again. We should abandon it.

msgpackr uses BigInt for the huge numbers in the MessagePack. I didn't want to mess with any of the logic in toHexDigits() as it scared me so I thought the safest thing to do was to pass the huge numbers around as strings.

---

This depends on #30.