### PR TITLE
Remove CircleCI node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,6 @@ references:
 
 version: 2.1
 
-orbs:
-  node: circleci/node@5.0.3
-
 jobs:
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Install npm v7.20.2 if node-version is 14.19
           command: |
-            if << parameters.node-version >> == "14.19" ; then
+            if "<< parameters.node-version >>" == "14.19" ; then
               npm install -g npm@7.20.2
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ references:
 version: 2.1
 
 orbs:
-  node: circleci/node@4.6.0
+  node: circleci/node@5.0.3
 
 jobs:
 
@@ -77,8 +77,7 @@ jobs:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "7"
+      - run: npm install -g npm@7.20.2
       - run:
           name: Install project dependencies
           command: make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Install npm v7.20.2 if node-version is 14.19
           command: |
-            if << matrix.node-version >> == "14.19" ; then
+            if << parameters.node-version >> == "14.19" ; then
               npm install -g npm@7.20.2
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,12 @@ jobs:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
       - *restore_npm_cache
-      - run: npm install -g npm@7.20.2
+      - run:
+          name: Install npm v7.20.2 if node-version is 14.19
+          command: |
+            if << matrix.node-version >> == "14.19" ; then
+              npm install -g npm@7.20.2
+            fi
       - run:
           name: Install project dependencies
           command: make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Install npm v7.20.2 if node-version is 14.19
           command: |
-            if "<< parameters.node-version >>" == "14.19" ; then
+            if [[ "<< parameters.node-version >>" == "14.19" ]] ; then
               npm install -g npm@7.20.2
             fi
       - run:


### PR DESCRIPTION
@AniaMakes was looking at #34 to try and upgrade the CircleCI node orb to v5:
- [Slack thread 1](https://financialtimes.slack.com/archives/C02ST9MNV0S/p1669888756520869)
- [Slack thread 2](https://financialtimes.slack.com/archives/C02ST9MNV0S/p1669977251520729)

v5 of the node orb removes support for the `node/install-npm` command, which was the only thing we were using the orb for, and was causing the build to fail.

From speaking with Ania:
- if node version is 14, we need to upgrade the default npm v6 to npm v7
- if node version is 16, we're happy with the default provided npm v8

---

This PR:

- uses an if statement to install npm v7 for node v14 builds
- removes the CircleCI node orb as it's no longer used, so you no longer need to worry about upgrading it in the future.

Thanks @hamza-samih and @Seraph2000 for helping talk through and solve the problem! 🙂 

Closes #34 .

I think this PR should also fix your [failing nightly build issue for node v14 builds](https://app.circleci.com/pipelines/github/Financial-Times/session-decoder-js/1016/workflows/f3c92815-2110-4e4c-98b6-69582a3350be/jobs/2861), as it will now install v7 of npm - but would be good to double check if that's the case.