### PR TITLE
ACC-2429: node upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.20"
+        default: "18.17"
         type: string
   container_config_lambda_node: &container_config_lambda_node
     working_directory: ~/project/build
@@ -17,11 +17,10 @@ references:
       - image: lambci/lambda:build-nodejs<< parameters.node-version >>
     parameters:
       node-version:
-        default: "18.15"
+        default: "18.17"
         type: string
 
-  workspace_root: &workspace_root
-    ~/project
+  workspace_root: &workspace_root ~/project
 
   attach_workspace: &attach_workspace
     attach_workspace:
@@ -29,19 +28,19 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v1-dependency-npm-{{ checksum "package.json" }}-
-        - v1-dependency-npm-{{ checksum "package.json" }}
-        - v1-dependency-npm-
+      - v1-dependency-npm-{{ checksum "package.json" }}-
+      - v1-dependency-npm-{{ checksum "package.json" }}
+      - v1-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
-        paths:
+      key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+      paths:
         - ./node_modules/
 
   restore_npm_cache: &restore_npm_cache
     restore_cache:
-        <<: *npm_cache_keys
+      <<: *npm_cache_keys
 
   filters_only_main: &filters_only_main
     branches:
@@ -72,7 +71,9 @@ jobs:
       - checkout
       - run:
           name: Checkout next-ci-shared-helpers
-          command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
+          command: git clone --depth 1
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - run:
           name: Install npm v8.19.4 if node-version is 16.20
@@ -138,14 +139,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15" ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15"  ]
+              node-version: [ "16.20", "18.17" ]
 
   build-test-publish:
     jobs:
@@ -155,7 +156,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15"  ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -164,13 +165,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15" ]
+              node-version: [ "16.20", "18.17" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v18.15
+            - test-v18.17
 
   nightly:
     triggers:
@@ -183,7 +184,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15"  ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -191,7 +192,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.20", "18.15"  ]
+              node-version: [ "16.20", "18.17" ]
 
 notify:
   webhooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/session-decoder-js",
       "version": "1.3.0",
-      "hasInstallScript": true,
       "dependencies": {
         "base64url": "3.0.1",
         "msgpackr": "^1.8.5"
@@ -23,7 +22,7 @@
       },
       "engines": {
         "node": "16.x || 18.x",
-        "npm": "8.x || 9.x"
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "src/session-decoder.js",
   "scripts": {
     "test": "",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine && { [ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine; }"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "base64url": "3.0.1",
@@ -21,8 +20,7 @@
     "snyk": "^1.1137.0"
   },
   "volta": {
-    "node": "16.14.0",
-    "npm": "7.20.2"
+    "node": "18.17.0"
   },
   "husky": {
     "hooks": {
@@ -33,6 +31,6 @@
   },
   "engines": {
     "node": "16.x || 18.x",
-    "npm": "8.x || 9.x"
+    "npm": "7.x || 8.x || 9.x"
   }
 }


### PR DESCRIPTION
You’ll need to upgrade the package to Node, release a new version, and implement that new version in consuming apps, ensuring everything works well in that consuming app
The platforms team have provided a [migration script](https://github.com/Financial-Times/platform-scripts/blob/main/upgrade-node-18/README.md).

Ticket:
[ACC-2429](https://financialtimes.atlassian.net/browse/ACC-2429)

[ACC-2429]: https://financialtimes.atlassian.net/browse/ACC-2429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ